### PR TITLE
support for encoding dumped instances

### DIFF
--- a/python-cim/cim/formatters.py
+++ b/python-cim/cim/formatters.py
@@ -91,7 +91,7 @@ def dump_layout(cd, cl):
     return "\n".join(ret)
 
 
-def dump_instance(i):
+def dump_instance(i, encoding=None, encoding_errors='strict'):
     """ :type i: ClassInstance """
     # TODO: migrate to templating?
     ret = []
@@ -118,4 +118,12 @@ def dump_instance(i):
         else:
             ret.append("  {key:s}=nil".format(key=prop.name))
         ret.append("")
-    return "\n".join(ret)
+
+    instance_str = "\n".join(ret)
+
+    # encode to specified encoding (which returns a byte array),
+    # and then decode back to a string
+    if encoding:
+        instance_str = instance_str.encode(encoding=encoding, errors=encoding_errors).decode(encoding)
+
+    return instance_str

--- a/python-cim/samples/dump_class_instance.py
+++ b/python-cim/samples/dump_class_instance.py
@@ -64,7 +64,7 @@ def main(type_, path, namespaceName, className, key_specifier=None):
         print("%s" % "=" * 80)
         #print(compute_instance_hash(index, instance))
         try:
-            print(dump_instance(instance))
+            print(dump_instance(instance, encoding='ascii', encoding_errors='ignore'))
         except:
             print("ERROR: failed to dump class instance!")
             print(traceback.format_exc())


### PR DESCRIPTION
Instances with property values that contain non-ascii characters result in an unhandled exception in samples/dump_class_instance.py when attempting to print the instance. This PR adds support for specify an encoding when formatting an instance.
